### PR TITLE
Add URL prefix configurations and auth handlers

### DIFF
--- a/Sources/Chica/Chica.docc/Registration.md
+++ b/Sources/Chica/Chica.docc/Registration.md
@@ -2,9 +2,11 @@
 
 Register your project with a Mastodon instance.
 
-To make API requests that require authentication, your project must be registered and granted access to a user's account with an access token.
+To make API requests that require authentication, your project must be registered and granted access to a user's account
+with an access token.
 
-Registering an application on a specific Mastodon instance for obtaining a token is accomplished with a POST request to the specific endpoint:
+Registering an application on a specific Mastodon instance for obtaining a token is accomplished with a POST request to
+the specific endpoint:
 
 ```swift
 let client: Application? = try! await Chica.shared.request(.post, for: .apps, params:
@@ -19,7 +21,8 @@ let client: Application? = try! await Chica.shared.request(.post, for: .apps, pa
 
 ## OAuth
 
-Every time you do a request, Chica tries to add a Bearer token as a header parameter. So, all we need to do is obtain an access token.
+Every time you do a request, Chica tries to add a Bearer token as a header parameter. So, all we need to do is obtain an
+access token.
 
 For this, first, you need to start the authorization flow:
 
@@ -35,19 +38,24 @@ This will:
 2. Once it's registered the application, save the client_id and client_secret in the device's login keychain.
 3. Open safari, asking for authorization to the user.
 
-Until this, you'll already have had registered an application and asked the user for authorization, but we are still missing the code that is returned by the instance through the redirect uri.
+Until this, you'll already have had registered an application and asked the user for authorization, but we are still
+missing the code that is returned by the instance through the redirect uri.
 
-For this reason, you'll need to add a deeplink handler that will tell chica what's the user authorization code, or you can use the one built-in!
+For this reason, you'll need to add a deeplink handler that will tell chica what's the user authorization code, or you
+can use the one built-in!
 
 ```swift
 Chica.handleURL(url: url, actions: [:]) // Where url is the redirect_uri, with the data we need as the query parameters.
 ```
 
-> Important: As of version 1.0 of Chica, only `starlight://` is supported as redirect uri. In future versions the option to add other redirect uris will be added.
+> Important: By default, Chica uses the URL prefix of `starlight://`. To change the URL prefix to match your specific
+> app, call ``Chica/Chica/setRequestPrefix(to:)`` when your app is initialized or loaded.
 
-This function will scan if the url contains "oauth", and if it does, it will handle with obtaining the user authorization code by itself.
+This function will scan if the url contains "oauth", and if it does, it will handle with obtaining the user
+authorization code by itself.
 
-One good thing about this deep link handler is that you can also use it for your own purposes, thanks to the `actions` parameter:
+One good thing about this deep link handler is that you can also use it for your own purposes, thanks to the `actions`
+parameter:
 
 ```swift
 Chica.handleURL(url: URL(string: "starlight://whatever?test=true")!, actions:
@@ -69,6 +77,7 @@ func doWhatever(_ parameters: [String : String]?) {
 }
 ```
 
-Once you get the user authorization code, Chica will obtain the Token, and store it on the device's `login` keychain. Now, everytime you do a request, the access token will be attached as a header parameter.
+Once you get the user authorization code, Chica will obtain the Token, and store it on the device's `login` keychain.
+Now, everytime you do a request, the access token will be attached as a header parameter.
 
->Important: You also need to register the URL Scheme to your Xcode target or on Info.plist.
+>Important: You also need to register the URL Scheme you'd like to use to your Xcode target or in Info.plist.

--- a/Sources/Chica/chica.swift
+++ b/Sources/Chica/chica.swift
@@ -224,12 +224,23 @@ public class Chica: ObservableObject, CustomStringConvertible {
 
     }
 
-    /// Sets the URL prefix of the Chica client.
+    /// Sets the URL prefix of the Chica client when making requests.
     /// - Parameter urlPrefix: The URL prefix to use with this client.
     ///
-    /// During instantiation, URL prefix is set to `starlight://`.
+    /// When the Chica class is first instantiated, the default URL prefix used is `starlight://`. When this method is
+    /// called, any future requests made with ``request(_:for:params:)`` will use the new URL prefix.
+    ///
+    /// - Important: The URL prefix that is assigned to Chica should be a valid URL prefix type registered with your
+    ///     app in Xcode or in the app's Info.plist.
     public func setRequestPrefix(to urlPrefix: String) {
         self.urlPrefix = urlPrefix
+    }
+
+    /// Resets the URL prefix of the Chica client to the default URL prefix.
+    ///
+    /// When calling this method, future requests will use the default URL prefix of `starlight://`.
+    public func resetRequestPrefix() {
+        self.urlPrefix = Chica.DEFAULT_URL_PREFIX
     }
 
     public static func handleURL(url: URL, actions: [String: ([String: String]?) -> Void]) {

--- a/Sources/Chica/chica.swift
+++ b/Sources/Chica/chica.swift
@@ -79,7 +79,10 @@ public class Chica: ObservableObject, CustomStringConvertible {
         }
 
         /// Returns the URL that needs to be opened in the browser to allow the user to complete registration.
-        public func startOauthFlow(for instanceDomain: String) async {
+        /// - Parameter instanceDomain: The domain in which the instance lies to start authorization for.
+        /// - Parameter authHandler: An optional closure that runs once the URL is created to open. Defaults to
+        ///     nil, using `openURL` instead.
+        public func startOauthFlow(for instanceDomain: String, authHandler: ((URL) -> Void)? = nil) async {
 
             //  First, we initialize the keychain object
             let keychain = Keychain(service: Chica.OAuth.keychainService)
@@ -113,7 +116,11 @@ public class Chica: ObservableObject, CustomStringConvertible {
                 .queryItem("response_type", value: "code")
 
             //  And finally, we open the url in the browser.
-            openURL(url)
+            if let handler = authHandler {
+                handler(url)
+            } else {
+                openURL(url)
+            }
         }
 
         /// Continues with the OAuth flow after obtaining the user authorization code from the redirect URI


### PR DESCRIPTION
Previously, when a developer wanted to work with Chica, they had to use our Starlight prefix, `starlight://`. However, there could be a potential collision with multiple apps installed that use the URL prefix.

This PR attempts to fix this by adding URL configuration utilities to Chica. Chica will continue to use the default URL prefix of `starlight://` when initialized. However, a developer can run the following method `setRequestPrefix(to urlPrefix:)` when the app is launched or initialized:

```swift
ContentView()
	.onAppear {
		Chica.shared.setRequestPrefix(for: "chrysalis://")
	}
```

Future requests will now use the new URL prefix instead of the default. To maintain our abstraction layer, the URL prefix variable is kept as a fileprivate field to Chica.

If the developer wants to use the default URL prefix again, they can call `resetRequestPrefix()`.

**Update**  
This PR also adds a new optional `authHandler` parameter to the `Chica.OAuth.startOauthFlow` method to intercept opening the URL if necessary. This should allow developers the ability to open this URL via a different means, especially given the App Store Guidelines*.

```swift
Chica.OAuth.shared.startOauthFlow(for: "mastodon.online") { authUrl in
    // Do something with the authUrl here...
}
```

> *Note: The exact guideline is not stated, but apps that redirect to Safari to log in have been rejected because it "provides a poor user experience".